### PR TITLE
Support for Dual Wield

### DIFF
--- a/Source/HarmonyPatches/PawnPatches/CarriedWeaponDrawing.cs
+++ b/Source/HarmonyPatches/PawnPatches/CarriedWeaponDrawing.cs
@@ -2,6 +2,7 @@
 using System.Reflection;
 using System.Reflection.Emit;
 using HarmonyLib;
+using UnityEngine;
 using Verse;
 
 namespace YayoAnimation.HarmonyPatches.PawnPatches;
@@ -18,14 +19,31 @@ public static class CarriedWeaponDrawing
             AccessTools.DeclaredField(typeof(PawnRenderUtility), nameof(PawnRenderUtility.EqLocSouth)),
             AccessTools.DeclaredField(typeof(PawnRenderUtility), nameof(PawnRenderUtility.EqLocWest)),
         };
+
+        HashSet<OpCode> ldLoc =
+        [
+            OpCodes.Ldloc_0,
+            OpCodes.Ldloc_1,
+            OpCodes.Ldloc_2,
+            OpCodes.Ldloc_3,
+            OpCodes.Ldloc_S,
+            OpCodes.Ldloc
+        ];
+
         var drawEquipmentAiming = MethodUtil.MethodOf(PawnRenderUtility.DrawEquipmentAiming);
 
         var addWiggleToCarryPos = MethodUtil.MethodOf(AimingPatch.AddWiggleToCarryPos);
+        var addWiggleToCarryPosCounter = MethodUtil.MethodOf(AimingPatch.AddWiggleToCarryPosCounter);
         var addWiggleToAngle = MethodUtil.MethodOf(AimingPatch.AddWiggleToAngle);
 
         var patchedAimingCalls = 0;
         var patchedFields = 0;
 
+        // Check if Dual Wield is loaded, and if it's later in the mod list, if it's already applied the patch.
+        var dualWieldPatchField = ModsConfig.IsActive("MemeGoddess.DualWield") 
+            ? AccessTools.TypeByName("DualWield.Harmony.PawnRenderUtility_DrawCarriedWeapon")?.Field("PatchApplied") 
+            : null;
+        var dualWieldLoaded = dualWieldPatchField != null && dualWieldPatchField.GetValue(null) is true;
         foreach (var ci in instr)
         {
             // If DrawEquipmentAiming, then the last value on stack is float (angle) - replace it with ours
@@ -39,16 +57,21 @@ public static class CarriedWeaponDrawing
             yield return ci;
 
             // If any of the 4 static fields was loaded, call our method to add wiggle to it
-            if (ci.opcode == OpCodes.Ldsfld && ci.operand is FieldInfo field && locFields.Contains(field))
+            if (!dualWieldLoaded && ci.opcode == OpCodes.Ldsfld && ci.operand is FieldInfo field && locFields.Contains(field))
             {
                 yield return new CodeInstruction(OpCodes.Call, addWiggleToCarryPos);
 
                 patchedFields++;
             }
+            else if (dualWieldLoaded && ldLoc.Contains(ci.opcode) && ci.operand is LocalBuilder localBuilder && localBuilder.LocalType == typeof(Vector3))
+            {
+                yield return new CodeInstruction(OpCodes.Call, patchedFields % 2 == 0 ? addWiggleToCarryPos : addWiggleToCarryPosCounter);
+                patchedFields++;
+            }
         }
 
-        const int expectedPatchedAimingCalls = 1;
-        const int expectedPatchedFields = 4;
+        int expectedPatchedAimingCalls = dualWieldLoaded ? 2 : 1;
+        int expectedPatchedFields = dualWieldLoaded ? 2 : 4;
 
         if (patchedAimingCalls != expectedPatchedAimingCalls)
             Log.Error($"[{Core.ModName}] - patched incorrect number of calls to PawnRenderUtility.DrawEquipmentAiming (expected: {expectedPatchedAimingCalls}, patched: {patchedAimingCalls}) for method {baseMethod.GetNameWithNamespace()}");


### PR DESCRIPTION
I've recently continued [Dual Wield](https://steamcommunity.com/sharedfiles/filedetails/?id=3630049419), and someone asked if I could add support for Yayo's Animations. Rewrote a bunch of patches to not replace methods and everything, however there were still some compat issues.

#### When loading up, Yayo's Animations would look for 1 call to drawing a gun, there's 2 now because dual wielding.
<img width="815" height="71" alt="image" src="https://github.com/user-attachments/assets/3bca5c24-be99-4d00-b340-b69144fb379b" />

#### When doing the twirling, it'd offset it to the left and twirl both the same direction. Rather than moving away from the body, and twirling opposite directions.
<img width="112" height="119" alt="image" src="https://github.com/user-attachments/assets/26b910bb-33c3-4fd5-8011-2a33be34623e" />

### What's changed
I've added a check to the 2 patches to see if Dual Wield is installed, and if it's patches have already ran. If it checked just installed, and Yayo was run before Dual, it'd give an error about the expected patch count being wrong, but would still work fine. (Harmony reruns patches after a higher priority patch has been applied)

I duplicated the AddWiggleToCarryPos method as well, so that offhand can move to the right of the body. I feel like there's a better way to do this, but I couldn't think of one without messing with the stack too much. Happy to improve that part though.

The changes are set up in a way where both mods will work with or without the compat branches merged/released, they'll just have the issues I listed above if newer Dual Wield version is ran with older Yayo's Animations

If you'd like to check out the compat I have on Dual Wield, the PR is [#1](https://github.com/MemeGoddess/DualWield/pull/1)